### PR TITLE
Upping DW support from 0.9.1 to 0.9.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+target/
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dropwizard-peer-authenticator
 Dropwizard module to enable BasicAuth security around a service with convenience factories for reading in lists of (users, passwords) who are authorized to make requests of your service.
 
-This artifact provides a Dropwizard Configuration/Factory class that enables convenient registration of an authorization filter with a Dropwizard Jersey Server.  This artifact is essentially a configuration wrapper around the documentation provided at https://dropwizard.github.io/dropwizard/manual/auth.html
+This artifact provides a Dropwizard Configuration/Factory class that enables convenient registration of an authorization filter with a Dropwizard Jersey Server.  This artifact is essentially a configuration wrapper around the documentation provided at http://www.dropwizard.io/0.9.2/docs/manual/auth.html
 
 A "Peer" object is a (username, password) POJO that models a remote service or user invoking some endpoint in your Dropwizard service.  The AllowedPeerAuthenticator loads a list of allowed peers from some source and then registers itself with Jersey to provide endpoint-level authentication on top of HTTP BasicAuth.
 
@@ -15,7 +15,7 @@ Check [./RELEASE_NOTES.md](./RELEASE_NOTES.md) for the latest/best version for y
 </dependency>
 ```
 
-In general, the 1.x.y versions are compatible with Dropwizard-0.8.1 while the 2.x.y versions are compatible with Dropwizard-0.9.1
+In general, the 1.x.y versions are compatible with Dropwizard-0.8.1 while the 2.x.y versions are compatible with Dropwizard-0.9.2
 
 ## Example configuration : peer file
 
@@ -101,7 +101,7 @@ If you use this configuration option, you must provide an equal number of userna
 
 ## Caching
 
-As mentioned in https://dropwizard.github.io/dropwizard/manual/auth.html, caching may be an important concern if the backing stores for the authenticators is not capable of high throughput (this isn't really a concern for our flat file or strings, but caching support is provided for future extensibility).  If you provide a "cachePolicy" configuration option, the Authenticator that is registered with Jersey will be of the type CachingAuthenticator.  For example:
+As mentioned in http://www.dropwizard.io/0.9.2/docs/manual/auth.html, caching may be an important concern if the backing stores for the authenticators is not capable of high throughput (this isn't really a concern for our flat file or strings, but caching support is provided for future extensibility).  If you provide a "cachePolicy" configuration option, the Authenticator that is registered with Jersey will be of the type CachingAuthenticator.  For example:
 
 ```yaml
 allowedPeers: 
@@ -124,3 +124,4 @@ allowedPeers:
 
 * add checkstyle & better maven site generation
 * support Chained Factories?
+* support the Authorizer interface in the creation of the `new AuthDynamicFeature`... right now this is 100% authenticator

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 # Release notes for dropwizard-peer-authenticator
 
-## 2.0.0 Release Date 2015/11/06
+## 2.0.0 Release Date 2016/02/04
 
-* Upgrading to Dropwizard-0.9.1
+* Upgrading to Dropwizard-0.9.2
 
 ## 1.0.2 Release Date 2015/08/25
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <version.guava>18.0</version.guava>
         <version.slf4j>1.7.12</version.slf4j>
-        <version.dropwizard>0.9.1</version.dropwizard>
+        <version.dropwizard>0.9.2</version.dropwizard>
     </properties>
     
     <dependencies>

--- a/src/main/java/com/washingtonpost/dw/auth/AllowedPeerConfiguration.java
+++ b/src/main/java/com/washingtonpost/dw/auth/AllowedPeerConfiguration.java
@@ -2,6 +2,7 @@ package com.washingtonpost.dw.auth;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilderSpec;
 import com.washingtonpost.dw.auth.dao.FlatFilePeerDAO;
 import com.washingtonpost.dw.auth.dao.StringPeerDAO;
@@ -15,7 +16,6 @@ import io.dropwizard.auth.basic.BasicCredentialAuthFilter;
 import io.dropwizard.auth.basic.BasicCredentials;
 import io.dropwizard.setup.Environment;
 import java.io.InputStream;
-import jersey.repackaged.com.google.common.base.Preconditions;
 
 /**
  * <p>Container for configuration, in the "config + factory" pattern that DropWizard likes</p>
@@ -152,7 +152,7 @@ public class AllowedPeerConfiguration {
      * <p>If a credentialFile is provided, this method will use that file to populate the list of Peers the Authenticator
      * checks during request processing.  If instead the "users" and "passwords" Strings are provided, this method will use
      * those to populate the list of Peers.</p>
-     * @return An Authenticator appropriate for registering with Jersey as described 
+     * @return An Authenticator appropriate for registering with Jersey as described
      * https://dropwizard.github.io/dropwizard/manual/auth.html
      */
     public Authenticator<BasicCredentials, Peer> createAuthenticator() {

--- a/src/main/java/com/washingtonpost/dw/auth/dao/StringPeerDAO.java
+++ b/src/main/java/com/washingtonpost/dw/auth/dao/StringPeerDAO.java
@@ -1,9 +1,9 @@
 package com.washingtonpost.dw.auth.dao;
 
+import com.google.common.base.Preconditions;
 import com.washingtonpost.dw.auth.model.Peer;
 import java.util.Collection;
 import java.util.HashSet;
-import jersey.repackaged.com.google.common.base.Preconditions;
 
 /**
  * <p>A simple implementation of a PeerDAO that assumes two strings contains a list of users and passwords in corresponding
@@ -15,7 +15,7 @@ import jersey.repackaged.com.google.common.base.Preconditions;
  */
 public class StringPeerDAO implements PeerDAO {
 
-    public final static String DEFAULT_DELIMITER = ";";
+    public static final String DEFAULT_DELIMITER = ";";
     private final Collection<Peer> peers;
 
 
@@ -37,7 +37,9 @@ public class StringPeerDAO implements PeerDAO {
         peers = new HashSet<>();
         for (int i=0; i<userArray.length; i++) {
             peers.add(new Peer(userArray[i], passArray[i]));
+            //CHECKSTYLE_OFF: RegexpSinglelineJava
             System.out.println("Added peer " + userArray[i] + " with password " + passArray[i]);
+            //CHECKSTYLE_ON: RegexpSinglelineJava
         }
     }
 

--- a/src/main/java/com/washingtonpost/dw/auth/package-info.java
+++ b/src/main/java/com/washingtonpost/dw/auth/package-info.java
@@ -1,4 +1,4 @@
-package com.washingtonpost.arc.auth.service.peer;
+package com.washingtonpost.dw.auth;
 
 /**
  * <p>This package provides a stand-alone implementation of a DropWizard Authenticator interface that our principle REST service


### PR DESCRIPTION
Also, the README talks about a firm 2.0.0 release from December, but I
don't think that ever happened because Maven central only shows a 1.0.1
and a 1.0.2 version:
https://search.maven.org/#search%7Cga%7C1%7Cdropwizard-peer-authenticator

So assuming Greg merges & releases this badboy today, marking the
release date in RELEASE_NOTEs as 2016/02/04
