### PR TITLE
Dropwizard 1.0.0 library compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
     </scm>
     
     <properties>
-        <version.dropwizard>0.9.2</version.dropwizard>
-        <version.guava>18.0</version.guava>
+        <version.dropwizard>1.0.0</version.dropwizard>
+        <version.guava>19.0</version.guava>
         <version.jasypt>1.9.2</version.jasypt>
         <version.jcommander>1.48</version.jcommander>
         <version.maven.shade>2.4.2</version.maven.shade>
-        <version.slf4j>1.7.12</version.slf4j>
+        <version.slf4j>1.7.21</version.slf4j>
     </properties>
     
     <dependencies>

--- a/src/main/java/com/washingtonpost/dw/auth/AllowedPeerAuthenticator.java
+++ b/src/main/java/com/washingtonpost/dw/auth/AllowedPeerAuthenticator.java
@@ -1,6 +1,5 @@
 package com.washingtonpost.dw.auth;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 import com.washingtonpost.dw.auth.dao.PeerDAO;
@@ -8,6 +7,7 @@ import com.washingtonpost.dw.auth.model.Peer;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.basic.BasicCredentials;
+import java.util.Optional;
 import java.util.Set;
 import org.jasypt.util.password.PasswordEncryptor;
 import org.slf4j.Logger;
@@ -53,7 +53,7 @@ public class AllowedPeerAuthenticator implements Authenticator<BasicCredentials,
         else {
             LOGGER.debug("{} is not known in our list of allowed peers", credentials.getUsername());
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     /*
@@ -67,7 +67,7 @@ public class AllowedPeerAuthenticator implements Authenticator<BasicCredentials,
 
         if (peers.isEmpty()) {
             LOGGER.debug("No peer named {} found in our allowed-peers file", credentials.getUsername());
-            return Optional.absent();
+            return Optional.empty();
         }
         else {
             Peer peer = peers.stream().findFirst().get();
@@ -77,7 +77,7 @@ public class AllowedPeerAuthenticator implements Authenticator<BasicCredentials,
             }
             else {
                 LOGGER.debug("{} is not known in our list of allowed peers", credentials.getUsername());
-                return Optional.absent();
+                return Optional.empty();
             }
         }
     }

--- a/src/test/java/com/washingtonpost/dw/auth/TestAllowedPeerAuthenticator.java
+++ b/src/test/java/com/washingtonpost/dw/auth/TestAllowedPeerAuthenticator.java
@@ -1,11 +1,11 @@
 package com.washingtonpost.dw.auth;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.washingtonpost.dw.auth.dao.PeerDAO;
 import com.washingtonpost.dw.auth.model.Peer;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.basic.BasicCredentials;
+import java.util.Optional;
 import java.util.Set;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This PR does two things:
- Updates library versions to match the versions in DW 1.0.0
- Transitions the `Authenticator` interface from guava's `Optional` to java's `Optional`
