### PR TITLE
Upgrading peer-authenticator to dropwizard-1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,24 @@ This artifact provides a Dropwizard Configuration/Factory class that enables con
 A "Peer" object is a (username, password) POJO that models a remote service or user invoking some endpoint in your Dropwizard service.  The AllowedPeerAuthenticator loads a list of allowed peers from some source and then registers itself with Jersey to provide endpoint-level authentication on top of HTTP BasicAuth.  Because this is just a BasicAuth authenticator, your DW service should only be accessed over HTTPS.
 
 ## Maven dependency
-Check [./RELEASE_NOTES.md](./RELEASE_NOTES.md) for the latest/best version for your needs, and add this to your pom:
+Check [./RELEASE_NOTES.md](./RELEASE_NOTES.md) or [maven central](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.washingtonpost.dropwizard%22%20AND%20a%3A%22dropwizard-peer-authenticator%22) for the latest/best version for your needs, and add this to your pom:
 ```
 <dependency>
     <groupId>com.washingtonpost.dropwizard</groupId>
     <artifactId>dropwizard-peer-authenticator</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>Major.Minor.Patch</version>
 </dependency>
 ```
 
-In general, the 1.x.y versions are compatible with Dropwizard-0.8-X while the 2.x.y versions are compatible with Dropwizard-0.9.X
+### Dropwizard Compatability Matrix
+
+| Dropwizard Version | Peer-Authenticator Version |
+|--------------------|----------------------------|
+|        0.8.*       |            1.x.y           |
+|        0.9.*       |            2.x.y           |
+|        1.0.*       |            3.x.y           |
+
+
 
 ## Example configuration : peer file
 
@@ -101,7 +109,7 @@ If you use this configuration option, you must provide an equal number of userna
 
 ## Caching
 
-As mentioned in http://www.dropwizard.io/0.9.2/docs/manual/auth.html, caching may be an important concern if the backing stores for the authenticators is not capable of high throughput (this isn't really a concern for our flat file or strings, but caching support is provided for future extensibility).  If you provide a "cachePolicy" configuration option, the Authenticator that is registered with Jersey will be of the type CachingAuthenticator.  For example:
+As mentioned in http://www.dropwizard.io/1.0.5/docs/manual/auth.html, caching may be an important concern if the backing stores for the authenticators is not capable of high throughput (this isn't really a concern for our flat file or strings, but caching support is provided for future extensibility).  If you provide a "cachePolicy" configuration option, the Authenticator that is registered with Jersey will be of the type CachingAuthenticator.  For example:
 
 ```yaml
 allowedPeers: 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # Release notes for dropwizard-peer-authenticator
 
-## 2.1.0 Release Date TBD
+## 3.0.0 Release Date 2016/12/xx
+
+* Supporting Dropwizard-1.0.5; this is a effectively a small change from returning Guava Optionals to java.util.Optional
+
+## 2.1.0 Release Date 2016/02/09
 
 * Adding JASYPT encryption of the allowed-peers.properties content
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,23 +3,24 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>com.washingtonpost</groupId>
-        <artifactId>wp-oss-parent-pom</artifactId>
-        <version>0.0.8</version>
+        <groupId>com.upside</groupId>
+        <artifactId>upside-parent-pom</artifactId>
+        <version>0.0.1</version>
     </parent>
+
     
     <groupId>com.washingtonpost.dropwizard</groupId>
     <artifactId>dropwizard-peer-authenticator</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0.upside-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>dropwizard-peer-authenticator</name>
     <description>Dropwizard Authenticator that uses BasicAuth (user,pass) pairs to control access to your service</description>
     
     <scm>
-        <connection>scm:git:git@github.com:washingtonpost/dropwizard-peer-authenticator.git</connection>
-        <developerConnection>scm:git:git@github.com:washingtonpost/dropwizard-peer-authenticator.git</developerConnection>
+        <connection>scm:git:git@github.com:upside-services/dropwizard-peer-authenticator.git</connection>
+        <developerConnection>scm:git:git@github.com:upside-services/dropwizard-peer-authenticator.git</developerConnection>
         <tag>HEAD</tag>
-        <url>http://github.com:washingtonpost/dropwizard-peer-authenticator</url>
+        <url>http://github.com:upside-services/dropwizard-peer-authenticator</url>
     </scm>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>com.washingtonpost.dropwizard</groupId>
     <artifactId>dropwizard-peer-authenticator</artifactId>
-    <version>3.0.0.upside-SNAPSHOT</version>
+    <version>3.0.0.upside</version>
     <packaging>jar</packaging>
     <name>dropwizard-peer-authenticator</name>
     <description>Dropwizard Authenticator that uses BasicAuth (user,pass) pairs to control access to your service</description>
@@ -19,7 +19,7 @@
     <scm>
         <connection>scm:git:git@github.com:upside-services/dropwizard-peer-authenticator.git</connection>
         <developerConnection>scm:git:git@github.com:upside-services/dropwizard-peer-authenticator.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>3.0.0.upside</tag>
         <url>http://github.com:upside-services/dropwizard-peer-authenticator</url>
     </scm>
     

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     
     <groupId>com.washingtonpost.dropwizard</groupId>
     <artifactId>dropwizard-peer-authenticator</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>dropwizard-peer-authenticator</name>
     <description>Dropwizard Authenticator that uses BasicAuth (user,pass) pairs to control access to your service</description>
@@ -23,12 +23,12 @@
     </scm>
     
     <properties>
-        <version.dropwizard>0.9.2</version.dropwizard>
-        <version.guava>18.0</version.guava>
+        <version.dropwizard>1.0.5</version.dropwizard>
+        <version.guava>20.0</version.guava>
         <version.jasypt>1.9.2</version.jasypt>
         <version.jcommander>1.48</version.jcommander>
         <version.maven.shade>2.4.2</version.maven.shade>
-        <version.slf4j>1.7.12</version.slf4j>
+        <version.slf4j>1.7.13</version.slf4j>
     </properties>
     
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>com.washingtonpost.dropwizard</groupId>
     <artifactId>dropwizard-peer-authenticator</artifactId>
-    <version>3.0.0.upside</version>
+    <version>3.0.1.upside-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>dropwizard-peer-authenticator</name>
     <description>Dropwizard Authenticator that uses BasicAuth (user,pass) pairs to control access to your service</description>
@@ -19,7 +19,7 @@
     <scm>
         <connection>scm:git:git@github.com:upside-services/dropwizard-peer-authenticator.git</connection>
         <developerConnection>scm:git:git@github.com:upside-services/dropwizard-peer-authenticator.git</developerConnection>
-        <tag>3.0.0.upside</tag>
+        <tag>HEAD</tag>
         <url>http://github.com:upside-services/dropwizard-peer-authenticator</url>
     </scm>
     

--- a/src/main/java/com/washingtonpost/dw/auth/AllowedPeerAuthenticator.java
+++ b/src/main/java/com/washingtonpost/dw/auth/AllowedPeerAuthenticator.java
@@ -1,6 +1,5 @@
 package com.washingtonpost.dw.auth;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 import com.washingtonpost.dw.auth.dao.PeerDAO;
@@ -8,6 +7,7 @@ import com.washingtonpost.dw.auth.model.Peer;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.basic.BasicCredentials;
+import java.util.Optional;
 import java.util.Set;
 import org.jasypt.util.password.PasswordEncryptor;
 import org.slf4j.Logger;
@@ -28,6 +28,7 @@ public class AllowedPeerAuthenticator implements Authenticator<BasicCredentials,
         this.passwordEncryptor = passwordEncryptor;
         LOGGER.info("Constructed Authenticator with {} allowed peers", this.allPeers.size());
     }
+
 
     @Override
     public Optional<Peer> authenticate(BasicCredentials credentials) throws AuthenticationException {
@@ -53,7 +54,7 @@ public class AllowedPeerAuthenticator implements Authenticator<BasicCredentials,
         else {
             LOGGER.debug("{} is not known in our list of allowed peers", credentials.getUsername());
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     /*
@@ -67,7 +68,7 @@ public class AllowedPeerAuthenticator implements Authenticator<BasicCredentials,
 
         if (peers.isEmpty()) {
             LOGGER.debug("No peer named {} found in our allowed-peers file", credentials.getUsername());
-            return Optional.absent();
+            return Optional.empty();
         }
         else {
             Peer peer = peers.stream().findFirst().get();
@@ -77,7 +78,7 @@ public class AllowedPeerAuthenticator implements Authenticator<BasicCredentials,
             }
             else {
                 LOGGER.debug("{} is not known in our list of allowed peers", credentials.getUsername());
-                return Optional.absent();
+                return Optional.empty();
             }
         }
     }

--- a/src/main/java/com/washingtonpost/dw/auth/dao/PeerDAO.java
+++ b/src/main/java/com/washingtonpost/dw/auth/dao/PeerDAO.java
@@ -20,7 +20,7 @@ public interface PeerDAO {
      * @param username A username to check for existence in {@code peers}
      * @return True, if {@code username} does not appear in {@code peers}, false otherwise
      */
-    default public boolean nameIsUnique(Set<Peer> peers, String username) {
+    default boolean nameIsUnique(Set<Peer> peers, String username) {
         return peers.stream().noneMatch((peer) -> (peer.getName().equals(username)));
     }
 }

--- a/src/test/java/com/washingtonpost/dw/auth/TestAllowedPeerAuthenticator.java
+++ b/src/test/java/com/washingtonpost/dw/auth/TestAllowedPeerAuthenticator.java
@@ -1,11 +1,11 @@
 package com.washingtonpost.dw.auth;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.washingtonpost.dw.auth.dao.PeerDAO;
 import com.washingtonpost.dw.auth.model.Peer;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.basic.BasicCredentials;
+import java.util.Optional;
 import java.util.Set;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
@gengel Would you do me a favor and release this?  It's a really straight-forward change that you guys don't _need_ to adopt unless/until you upgrade to dropwizard-1.0.x, but this will at least be here when you need it.

> Creates a 3.0.0-SNAPSHOT candidate release that conforms to the Dropwizard 1.0.5 Authenticator interface (http://www.dropwizard.io/1.0.5/docs/manual/auth.html).  Really, the _only_ change is that the Dropwizard guys changed the return type from a Guava Optional to a Java8 Optional.  Pretty straight forward.